### PR TITLE
Feat/create ec2 instance

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -17,6 +17,12 @@ const project = new awscdk.AwsCdkTypeScriptApp({
     '.env',
   ],
 
+  tsconfig: {
+    compilerOptions: {
+      noUnusedLocals: false,
+    },
+  },
+
   readme: {
     contents: `# CDK Project
 

--- a/src/lib/constructs/app.ts
+++ b/src/lib/constructs/app.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { aws_ec2 as ec2, aws_iam as iam } from 'aws-cdk-lib';
+import { IInstance } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 
 export interface Ec2Props {
@@ -7,6 +8,8 @@ export interface Ec2Props {
 }
 
 export class Ec2App extends Construct {
+  public readonly linuxinstance: IInstance;
+  // public readonly windowsinstance: IInstance;
 
   constructor(scope: Construct, id: string, props: Ec2Props) {
     super(scope, id);
@@ -24,7 +27,7 @@ export class Ec2App extends Construct {
       securityGroupIds: [eicSecurityGroup.securityGroupId],
     });
 
-    
+
     /* ============ KeyPair ============ */
     const keyPair = new ec2.KeyPair(this, 'KeyPair', {});
 
@@ -90,6 +93,8 @@ export class Ec2App extends Construct {
     linuxInstance.connections.allowFromAnyIpv4(ec2.Port.allIcmp());
     linuxInstance.connections.allowFrom(eicSecurityGroup, ec2.Port.SSH);
 
+    this.linuxinstance = linuxInstance;
+
 
     /* ============ EC2 Instance for Windows ============ */
 
@@ -128,5 +133,6 @@ export class Ec2App extends Construct {
     //   ],
     // });
 
+    // this.linuxinstance = windowsInstance;
   }
 }

--- a/src/lib/constructs/app.ts
+++ b/src/lib/constructs/app.ts
@@ -24,35 +24,7 @@ export class Ec2App extends Construct {
       securityGroupIds: [eicSecurityGroup.securityGroupId],
     });
 
-    //   /* ============ Security Group ============ */
-
-    //   // Security Group for Instance of linuxInstance
-    //   const linuxSg = new ec2.SecurityGroup(this, 'linuxSg', {
-    //     vpc: props.vpc,
-    //     allowAllOutbound: true,
-    //   });
-    //   this.linuxSg = linuxSg;
-
-
-    //  // Security Group for Instance of windowsInstance
-    //   const windowsSg = new ec2.SecurityGroup(this, 'windowsSg', {
-    //     vpc: props.vpc,
-    //     allowAllOutbound: true,
-    //   });
-    //   this.windowsSg = windowsSg;
-
-    //   // Security Group Rules of linuxInstance
-    //   // linuxSg.addEgressRule(ec2.Peer.anyIpv4(), ec2.Port.allTcp());
-    //   linuxSg.addIngressRule(eicSg, ec2.Port.SSH);
-
-    //   // Security Group Rules of windowsInstance
-    //   windowsSg.addIngressRule(eicSg, ec2.Port.RDP);
-
-    //   // Security Group Rules of EC2 Instance Connect
-    //   eicSg.addEgressRule(linuxSg, ec2.Port.SSH);
-    //   eicSg.addEgressRule(windowsSg, ec2.Port.RDP);
-
-
+    
     /* ============ KeyPair ============ */
     const keyPair = new ec2.KeyPair(this, 'KeyPair', {});
 

--- a/src/lib/constructs/app.ts
+++ b/src/lib/constructs/app.ts
@@ -115,7 +115,7 @@ export class Ec2App extends Construct {
       ],
     });
 
-    linuxInstance.connections.allowFromAnyIpv4(ec2.Port.icmpPing());
+    linuxInstance.connections.allowFromAnyIpv4(ec2.Port.allIcmp());
     linuxInstance.connections.allowFrom(eicSecurityGroup, ec2.Port.SSH);
 
 

--- a/src/lib/constructs/app.ts
+++ b/src/lib/constructs/app.ts
@@ -1,0 +1,155 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { aws_ec2 as ec2 } from 'aws-cdk-lib';
+import { aws_iam as iam } from 'aws-cdk-lib';
+
+export interface Ec2Props {
+  vpc: ec2.IVpc;
+  eicSecurityGroup: ec2.ISecurityGroup;
+}
+
+export class Ec2Instance extends Construct {
+  public readonly linuxSg: ec2.ISecurityGroup;
+  public readonly windowsSg: ec2.ISecurityGroup;
+
+  constructor(scope: Construct, id: string, props: Ec2Props) {
+    super(scope, id);
+
+    const accountId = cdk.Stack.of(this).account;
+    const eicSg = props.eicSecurityGroup;
+
+
+    /* ============ Security Group ============ */
+  
+    // Security Group for Instance of linuxInstance
+    const linuxSg = new ec2.SecurityGroup(this, 'linuxSg', {
+      vpc: props.vpc,
+      allowAllOutbound: true,
+    });
+    this.linuxSg = linuxSg;
+
+
+   // Security Group for Instance of windowsInstance
+    const windowsSg = new ec2.SecurityGroup(this, 'windowsSg', {
+      vpc: props.vpc,
+      allowAllOutbound: true,
+    });
+    this.windowsSg = windowsSg;
+
+    // Security Group Rules of linuxInstance
+    // linuxSg.addEgressRule(ec2.Peer.anyIpv4(), ec2.Port.allTcp());
+    linuxSg.addIngressRule(eicSg, ec2.Port.SSH);
+
+    // Security Group Rules of windowsInstance
+    windowsSg.addIngressRule(eicSg, ec2.Port.RDP);
+
+    // Security Group Rules of EC2 Instance Connect
+    eicSg.addEgressRule(linuxSg, ec2.Port.SSH);
+    eicSg.addEgressRule(windowsSg, ec2.Port.RDP);
+
+
+
+    /* ============ KeyPair ============ */
+    const keyPair = new ec2.KeyPair(this, 'KeyPair', {});
+
+
+    /* ============ InstanceProfile ============ */
+    const InstanceRole = new iam.Role(this, 'InstanceRole', {
+      assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+      path: '/',
+      managedPolicies: [
+        { managedPolicyArn: 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore' },
+        { managedPolicyArn: 'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy' },
+      ],
+    });
+
+
+    /* ============ EC2 Instance for Linux ============ */
+
+    // UserData for Linux (setup httpd)
+    const linuxUserdata = ec2.UserData.forLinux({ shebang: '#!/bin/bash' });
+    linuxUserdata.addCommands(
+      'sudo dnf -y install httpd',
+      'sudo echo "<h1>Hello from $(hostname)</h1>" > /var/www/html/index.html',
+      'sudo chown apache:apache /var/www/html/index.html',
+      'sudo systemctl enable httpd',
+      'sudo systemctl start httpd',
+    );
+
+    // AMI (Linux)
+    // const linuxAmi = ec2.MachineImage.latestAmazonLinux2023({
+    //   cachedInContext: true,
+    // });
+
+    const linuxAmi = ec2.MachineImage.lookup({
+      name: 'al2023-ami-2023.6.20241212.0-kernel-6.1-x86_64',
+      owners: [
+        'amazon',
+        accountId,
+      ]
+    });
+
+    // EC2 instance (Linux)
+    const linuxInstance = new ec2.Instance(this, 'linuxInstance', {
+      vpc: props.vpc,
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
+      machineImage: linuxAmi,
+      role: InstanceRole,
+      vpcSubnets: {
+        subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+      },
+      securityGroup: linuxSg,
+      userData: linuxUserdata,
+      keyPair: keyPair,
+      blockDevices: [
+        {
+          deviceName: '/dev/xvda',
+          volume: ec2.BlockDeviceVolume.ebs(20, {
+            encrypted: true,
+            volumeType: ec2.EbsDeviceVolumeType.GP3,
+          }),
+        },
+      ],
+    });
+
+    linuxInstance.connections.allowFromAnyIpv4(ec2.Port.icmpPing());
+
+
+    /* ============ EC2 Instance for Windows ============ */
+
+    // // UserData for Windows
+    // const windowsUserdata = ec2.UserData.forWindows();
+
+    // // AMI (Windows)
+    // const ws2016Ami = ec2.MachineImage.lookup({
+    //   name: 'Windows_Server-2016-English-Full-Base-2024.12.13',
+    //   owners: [
+    //     'amazon',
+    //     accountId,
+    //   ]
+    // });
+
+    // EC2 instance (Windows)
+    // const windowsInstance = new ec2.Instance(this, 'windowsInstance', {
+    //   vpc: props.vpc,
+    //   instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
+    //   machineImage: ws2016Ami,
+    //   keyPair: keyPair,
+    //   role: InstanceRole,
+    //   vpcSubnets: {
+    //     subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+    //   },
+    //   securityGroup: windowsSg,
+    //   userData: windowsUserdata,
+    //   blockDevices: [
+    //     {
+    //       deviceName: '/dev/sda1',
+    //       volume: ec2.BlockDeviceVolume.ebs(30, {
+    //        encrypted: true,
+    //        volumeType: ec2.EbsDeviceVolumeType.GP3,
+    //       }),
+    //     },
+    //   ],
+    // });
+  }
+}

--- a/src/lib/constructs/network.ts
+++ b/src/lib/constructs/network.ts
@@ -7,7 +7,6 @@ export interface NetworkProps {
 
 export class Network extends Construct {
   public readonly vpc: ec2.IVpc;
-  public readonly eicSecurityGroup: ec2.ISecurityGroup;
 
   constructor(scope: Construct, id: string, props: NetworkProps) {
     super(scope, id);
@@ -38,18 +37,6 @@ export class Network extends Construct {
       ],
     });
     this.vpc = vpc;
-
-    // ========= EC2 Instance Connect =============== //
-    const eicSecurityGroup = new ec2.SecurityGroup(this, 'EicSg', {
-      vpc,
-      allowAllOutbound: false,
-    });
-
-    new ec2.CfnInstanceConnectEndpoint(this, 'Eic', {
-      subnetId: vpc.isolatedSubnets[0].subnetId,
-      securityGroupIds: [eicSecurityGroup.securityGroupId],
-    });
-    this.eicSecurityGroup = eicSecurityGroup;
 
   }
 }

--- a/src/lib/stacks/app-stack.ts
+++ b/src/lib/stacks/app-stack.ts
@@ -1,5 +1,6 @@
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import { Ec2App } from '../constructs/app';
 import { Network } from '../constructs/network';
 
 export interface AppStackProps extends StackProps {
@@ -10,8 +11,12 @@ export class AppStack extends Stack {
   constructor(scope: Construct, id: string, props: AppStackProps) {
     super(scope, id, props);
 
-    new Network(this, 'Network', {
+    const networking = new Network(this, 'Network', {
       vpcCidr: props.vpcCidr,
+    });
+
+    new Ec2App(this, 'Ec2App', {
+      vpc: networking.vpc,
     });
 
 

--- a/src/parameter.ts
+++ b/src/parameter.ts
@@ -14,8 +14,8 @@ dotenv.config();
 
 export const devParameter: AppParameter = {
   env: {
-    account: process.env.CDK_PROD_ACCOUNT,
-    region: process.env.CDK_PROD_REGION,
+    account: process.env.CDK_DEPLOY_ACCOUNT,
+    region: process.env.CDK_DEPLOY_REGION,
   },
   envName: 'Develop',
   repository: 'TatsuyaOoki/cdk-aws-network',

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -10,12 +10,12 @@ exports[`Snapshot 1`] = `
     },
   },
   "Resources": {
-    "NetworkEic381B19AB": {
+    "Ec2AppEic41EA4C20": {
       "Properties": {
         "SecurityGroupIds": [
           {
             "Fn::GetAtt": [
-              "NetworkEicSg49118B38",
+              "Ec2AppEicSg35A800DC",
               "GroupId",
             ],
           },
@@ -26,16 +26,14 @@ exports[`Snapshot 1`] = `
       },
       "Type": "AWS::EC2::InstanceConnectEndpoint",
     },
-    "NetworkEicSg49118B38": {
+    "Ec2AppEicSg35A800DC": {
       "Properties": {
-        "GroupDescription": "test/Network/EicSg",
+        "GroupDescription": "test/Ec2App/EicSg",
         "SecurityGroupEgress": [
           {
-            "CidrIp": "255.255.255.255/32",
-            "Description": "Disallow all traffic",
-            "FromPort": 252,
-            "IpProtocol": "icmp",
-            "ToPort": 86,
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
           },
         ],
         "VpcId": {
@@ -43,6 +41,150 @@ exports[`Snapshot 1`] = `
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "Ec2AppInstanceRole3F9B9B92": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+          "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+        ],
+        "Path": "/",
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "Ec2AppKeyPairE6956868": {
+      "Properties": {
+        "KeyFormat": "pem",
+        "KeyName": "testEc2AppKeyPair003D5C3F",
+        "KeyType": "rsa",
+      },
+      "Type": "AWS::EC2::KeyPair",
+    },
+    "Ec2ApplinuxInstance9ED8C3EE": {
+      "DependsOn": [
+        "Ec2AppInstanceRole3F9B9B92",
+      ],
+      "Properties": {
+        "AvailabilityZone": "dummy1a",
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "Encrypted": true,
+              "VolumeSize": 20,
+              "VolumeType": "gp3",
+            },
+          },
+        ],
+        "IamInstanceProfile": {
+          "Ref": "Ec2ApplinuxInstanceInstanceProfileDF1E0570",
+        },
+        "ImageId": "ami-1234",
+        "InstanceType": "t3.micro",
+        "KeyName": {
+          "Ref": "Ec2AppKeyPairE6956868",
+        },
+        "SecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "Ec2ApplinuxInstanceInstanceSecurityGroup3481696A",
+              "GroupId",
+            ],
+          },
+        ],
+        "SubnetId": {
+          "Ref": "NetworkVpcPrivateSubnet1Subnet6DD86AE6",
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "test/Ec2App/linuxInstance",
+          },
+        ],
+        "UserData": {
+          "Fn::Base64": "#!/bin/bash
+sudo dnf -y install httpd
+sudo echo "<h1>Hello from $(hostname)</h1>" > /var/www/html/index.html
+sudo chown apache:apache /var/www/html/index.html
+sudo systemctl enable httpd
+sudo systemctl start httpd",
+        },
+      },
+      "Type": "AWS::EC2::Instance",
+    },
+    "Ec2ApplinuxInstanceInstanceProfileDF1E0570": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "Ec2AppInstanceRole3F9B9B92",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "Ec2ApplinuxInstanceInstanceSecurityGroup3481696A": {
+      "Properties": {
+        "GroupDescription": "test/Ec2App/linuxInstance/InstanceSecurityGroup",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "from 0.0.0.0/0:ICMP Type 8",
+            "FromPort": 8,
+            "IpProtocol": "icmp",
+            "ToPort": -1,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "test/Ec2App/linuxInstance",
+          },
+        ],
+        "VpcId": {
+          "Ref": "NetworkVpc7FB7348F",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "Ec2ApplinuxInstanceInstanceSecurityGroupfromtestEc2AppEicSg7A0F1624226AB22D9E": {
+      "Properties": {
+        "Description": "from testEc2AppEicSg7A0F1624:22",
+        "FromPort": 22,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "Ec2ApplinuxInstanceInstanceSecurityGroup3481696A",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "Ec2AppEicSg35A800DC",
+            "GroupId",
+          ],
+        },
+        "ToPort": 22,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "NetworkVpc7FB7348F": {
       "Properties": {
@@ -97,14 +239,7 @@ exports[`Snapshot 1`] = `
     },
     "NetworkVpcPrivateSubnet1Subnet6DD86AE6": {
       "Properties": {
-        "AvailabilityZone": {
-          "Fn::Select": [
-            0,
-            {
-              "Fn::GetAZs": "",
-            },
-          ],
-        },
+        "AvailabilityZone": "dummy1a",
         "CidrBlock": "10.0.2.0/24",
         "MapPublicIpOnLaunch": false,
         "Tags": [
@@ -154,14 +289,7 @@ exports[`Snapshot 1`] = `
     },
     "NetworkVpcPrivateSubnet2Subnet1BDBE877": {
       "Properties": {
-        "AvailabilityZone": {
-          "Fn::Select": [
-            1,
-            {
-              "Fn::GetAZs": "",
-            },
-          ],
-        },
+        "AvailabilityZone": "dummy1b",
         "CidrBlock": "10.0.3.0/24",
         "MapPublicIpOnLaunch": false,
         "Tags": [
@@ -211,14 +339,7 @@ exports[`Snapshot 1`] = `
     },
     "NetworkVpcProtectedSubnet1Subnet3489B8A9": {
       "Properties": {
-        "AvailabilityZone": {
-          "Fn::Select": [
-            0,
-            {
-              "Fn::GetAZs": "",
-            },
-          ],
-        },
+        "AvailabilityZone": "dummy1a",
         "CidrBlock": "10.0.4.0/24",
         "MapPublicIpOnLaunch": false,
         "Tags": [
@@ -268,14 +389,7 @@ exports[`Snapshot 1`] = `
     },
     "NetworkVpcProtectedSubnet2SubnetB311854E": {
       "Properties": {
-        "AvailabilityZone": {
-          "Fn::Select": [
-            1,
-            {
-              "Fn::GetAZs": "",
-            },
-          ],
-        },
+        "AvailabilityZone": "dummy1b",
         "CidrBlock": "10.0.5.0/24",
         "MapPublicIpOnLaunch": false,
         "Tags": [
@@ -340,14 +454,7 @@ exports[`Snapshot 1`] = `
     },
     "NetworkVpcPublicSubnet1Subnet36933139": {
       "Properties": {
-        "AvailabilityZone": {
-          "Fn::Select": [
-            0,
-            {
-              "Fn::GetAZs": "",
-            },
-          ],
-        },
+        "AvailabilityZone": "dummy1a",
         "CidrBlock": "10.0.0.0/24",
         "MapPublicIpOnLaunch": true,
         "Tags": [
@@ -412,14 +519,7 @@ exports[`Snapshot 1`] = `
     },
     "NetworkVpcPublicSubnet2SubnetC427CCE0": {
       "Properties": {
-        "AvailabilityZone": {
-          "Fn::Select": [
-            1,
-            {
-              "Fn::GetAZs": "",
-            },
-          ],
-        },
+        "AvailabilityZone": "dummy1b",
         "CidrBlock": "10.0.1.0/24",
         "MapPublicIpOnLaunch": true,
         "Tags": [

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -16,7 +16,7 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "strict": true,


### PR DESCRIPTION
## 変更内容
EC2インスタンス作成用のコンストラクト作成
`constructs/app.ts`にEC2インスタンスの定義を追加
Windows用のEC2インスタンス作成の場合もコメントアウトで記述
併せてEC2 Instance Connectも作成するようにし、private subnetに配置されたインスタンスにも接続できるように設定
※現状、EICはL1でしか提供されておらず、SGの設定にconnectionsを利用できない

close #6 