### PR TITLE
Feat/rds az fixation

### DIFF
--- a/src/lib/constructs/data.ts
+++ b/src/lib/constructs/data.ts
@@ -21,6 +21,7 @@ export class DataApp extends Construct {
       engine: rds.DatabaseInstanceEngine.mysql({
         version: rds.MysqlEngineVersion.VER_8_0_40,
       }),
+      availabilityZone: props.instance.instanceAvailabilityZone,
       vpc: props.vpc,
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
       allocatedStorage: 20,

--- a/src/lib/constructs/data.ts
+++ b/src/lib/constructs/data.ts
@@ -23,15 +23,15 @@ export class DataApp extends Construct {
       }),
       availabilityZone: props.instance.instanceAvailabilityZone,
       vpc: props.vpc,
+      vpcSubnets: {
+        subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+      },
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
       allocatedStorage: 20,
       storageType: rds.StorageType.GP2,
       storageEncrypted: true,
       multiAz: false,
       publiclyAccessible: false,
-      vpcSubnets: {
-        subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
-      },
       parameters: {
         character_set_client: 'utf8mb4',
         character_set_connection: 'utf8mb4',

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -14,6 +14,12 @@ exports[`AppStackTest Snapshot 1`] = `
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "AllocatedStorage": "20",
+        "AvailabilityZone": {
+          "Fn::GetAtt": [
+            "Ec2ApplinuxInstance9ED8C3EE",
+            "AvailabilityZone",
+          ],
+        },
         "BackupRetentionPeriod": 1,
         "CopyTagsToSnapshot": true,
         "DBInstanceClass": "db.t3.micro",


### PR DESCRIPTION
## 変更内容
RDSインスタンスの作成先AZを指定

## 詳細
EC2インスタンスと同じAZに作成されるように修正
EC2インスタンスから動的にAZを取得し、同じAZに作成されるように設定
`availabilityZone: props.instance.instanceAvailabilityZone,`

close #14 