### PR TITLE
Feat/enable snapshot test

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -189,11 +189,21 @@
       "description": "Run tests",
       "steps": [
         {
-          "exec": "jest --passWithNoTests --updateSnapshot",
+          "exec": "jest --passWithNoTests --ci",
           "receiveArgs": true
         },
         {
           "spawn": "eslint"
+        }
+      ]
+    },
+    "test:update": {
+      "name": "test:update",
+      "description": "Update jest snapshots",
+      "steps": [
+        {
+          "exec": "jest --updateSnapshot --passWithNoTests --ci",
+          "receiveArgs": true
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,5 @@
 import { awscdk } from 'projen';
+import { UpdateSnapshot } from 'projen/lib/javascript';
 const project = new awscdk.AwsCdkTypeScriptApp({
   cdkVersion: '2.1.0',
   defaultReleaseBranch: 'main',
@@ -21,6 +22,10 @@ const project = new awscdk.AwsCdkTypeScriptApp({
     compilerOptions: {
       noUnusedLocals: false,
     },
+  },
+
+  jestOptions: {
+    updateSnapshot: UpdateSnapshot.NEVER,
   },
 
   readme: {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -87,7 +87,7 @@ npx projen build
 ### Update Snapshots
 If you made changes to the CDK stack and need to update the snapshot tests, run:
 \`\`\`sh
-npx projen test -u
+npx projen test:update
 \`\`\`
 This will regenerate the snapshot files based on the current CDK template.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npx projen build
 ### Update Snapshots
 If you made changes to the CDK stack and need to update the snapshot tests, run:
 ```sh
-npx projen test -u
+npx projen test:update
 ```
 This will regenerate the snapshot files based on the current CDK template.
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "synth": "npx projen synth",
     "synth:silent": "npx projen synth:silent",
     "test": "npx projen test",
+    "test:update": "npx projen test:update",
     "test:watch": "npx projen test:watch",
     "upgrade": "npx projen upgrade",
     "watch": "npx projen watch",


### PR DESCRIPTION
## 変更内容
スナップショットテストの有効化
REAME修正

## 詳細
スナップショットテスト実行時に以前のテンプレートと差異があった場合でも成功となる動作を修正し、差異がある場合は失敗するように変更。
また、README記載のテスト時のテンプレート更新コマンドを`npx projen test -u`から`npx projen test:update`に変更

close #9 