### PR TITLE
refactor: Remove unused imports

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,5 +1,5 @@
 import { awscdk } from "projen";
-import { UpdateSnapshot, PrettierOptions } from "projen/lib/javascript";
+import { UpdateSnapshot } from "projen/lib/javascript";
 const project = new awscdk.AwsCdkTypeScriptApp({
   cdkVersion: "2.1.0",
   defaultReleaseBranch: "main",


### PR DESCRIPTION
## 変更内容
未使用のインポートを削除

## 詳細
`.projenrc.ts`にて使用されていないimport が存在しているため削除を実施
`import { UpdateSnapshot, PrettierOptions } from "projen/lib/javascript";`
※PrettierOptionsはパラメータのKeyで利用しているが、importは不要